### PR TITLE
Fix Public Key retrieval error

### DIFF
--- a/src/main/java/com/vagdedes/spartan/configuration/SQLFeature.java
+++ b/src/main/java/com/vagdedes/spartan/configuration/SQLFeature.java
@@ -236,15 +236,16 @@ public class SQLFeature extends ConfigurationBuilder {
                 String driver = getDriver();
 
                 try {
-                    if (driver.length() == 0) {
+                    if (driver.isEmpty()) {
                         AwarenessNotifications.forcefullySend("SQL Configuration Error: Driver is blank");
                     } else {
                         String tlsVersion = getTLSVersion();
                         con = DriverManager.getConnection("jdbc:" + driver + "://" + host + ":" + port + "/" + database + "?" +
                                         "autoReconnect=true" +
                                         "&maxReconnects=10" +
-                                        (tlsVersion != null && tlsVersion.length() > 0 ? "&enabledTLSProtocols=TLSv" + tlsVersion : "") +
-                                        "&useSSL=" + getSSL(),
+                                        (tlsVersion != null && !tlsVersion.isEmpty() ? "&enabledTLSProtocols=TLSv" + tlsVersion : "") +
+                                        "&useSSL=" + getSSL() +
+                                        (!getSSL() ? "&allowPublicKeyRetrieval=true" : ""),
                                 user, password);
                         createTable(table);
                     }


### PR DESCRIPTION
This fixes crash:

```
[21:26:59] [Paper Watchdog Thread/INFO]: [Spartan 1.0: Java Edition Notification] [Spartan Phase 530] SQL Initial Connection Error:
Could not create connection to database server. Attempted reconnect 10 times. Giving up.
[21:26:59] [Paper Watchdog Thread/WARN]: java.sql.SQLNonTransientConnectionException: Could not create connection to database server. Attempted reconnect 10 times. Giving up.
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:111)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:98)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:90)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:64)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:74)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.ConnectionImpl.connectWithRetries(ConnectionImpl.java:885)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.ConnectionImpl.createNewIO(ConnectionImpl.java:810)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:438)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.ConnectionImpl.getInstance(ConnectionImpl.java:241)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.NonRegisteringDriver.connect(NonRegisteringDriver.java:189)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:681)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:229)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at Spartan2JavaEdition2Z5NNBNW.jar//me.vagdedes.spartan.d.d.N(SQLFeature.java:243)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at Spartan2JavaEdition2Z5NNBNW.jar//me.vagdedes.spartan.d.d.f(SQLFeature.java:262)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at Spartan2JavaEdition2Z5NNBNW.jar//me.vagdedes.spartan.d.d.M(SQLFeature.java:142)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at Spartan2JavaEdition2Z5NNBNW.jar//me.vagdedes.spartan.g.d.g.a(ResearchEngine.java:219)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at Spartan2JavaEdition2Z5NNBNW.jar//me.vagdedes.spartan.d.b.G(Config.java:270)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at Spartan2JavaEdition2Z5NNBNW.jar//me.vagdedes.spartan.g.d.a.af(Cache.java:161)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at Spartan2JavaEdition2Z5NNBNW.jar//me.vagdedes.spartan.Register.onDisable(Register.java:112)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:283)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugin(PaperPluginInstanceManager.java:225)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.disablePlugins(PaperPluginInstanceManager.java:149)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.disablePlugins(PaperPluginManagerImpl.java:92)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at org.bukkit.plugin.SimplePluginManager.disablePlugins(SimplePluginManager.java:528)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at org.bukkit.craftbukkit.v1_20_R3.CraftServer.disablePlugins(CraftServer.java:568)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at net.minecraft.server.MinecraftServer.t(MinecraftServer.java:975)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at net.minecraft.server.dedicated.DedicatedServer.t(DedicatedServer.java:824)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at net.minecraft.server.MinecraftServer.close(MinecraftServer.java:930)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at org.spigotmc.WatchdogThread.run(WatchdogThread.java:231)
[21:26:59] [Paper Watchdog Thread/WARN]: Caused by: com.mysql.cj.exceptions.CJException: Public Key Retrieval is not allowed
[21:26:59] [Paper Watchdog Thread/WARN]: 	at jdk.internal.reflect.GeneratedConstructorAccessor87.newInstance(Unknown Source)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:61)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:104)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:149)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:122)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.protocol.a.authentication.CachingSha2PasswordPlugin.nextAuthenticationStep(CachingSha2PasswordPlugin.java:154)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.protocol.a.authentication.CachingSha2PasswordPlugin.nextAuthenticationStep(CachingSha2PasswordPlugin.java:49)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.protocol.a.NativeAuthenticationProvider.proceedHandshakeWithPluggableAuthentication(NativeAuthenticationProvider.java:446)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.protocol.a.NativeAuthenticationProvider.connect(NativeAuthenticationProvider.java:215)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.protocol.a.NativeProtocol.connect(NativeProtocol.java:1428)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.NativeSession.connect(NativeSession.java:133)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.jdbc.ConnectionImpl.connectWithRetries(ConnectionImpl.java:829)
[21:26:59] [Paper Watchdog Thread/WARN]: 	... 23 more
[21:26:59] [Paper Watchdog Thread/WARN]: Caused by: com.mysql.cj.exceptions.UnableToConnectException: Public Key Retrieval is not allowed
[21:26:59] [Paper Watchdog Thread/WARN]: 	at jdk.internal.reflect.GeneratedConstructorAccessor86.newInstance(Unknown Source)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:61)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.exceptions.ExceptionFactory.createException(ExceptionFactory.java:85)
[21:26:59] [Paper Watchdog Thread/WARN]: 	at com.mysql.cj.protocol.a.authentication.CachingSha2PasswordPlugin.nextAuthenticationStep(CachingSha2PasswordPlugin.java:131)
[21:26:59] [Paper Watchdog Thread/WARN]: 	... 29 more
```

More context here https://stackoverflow.com/a/50438872 and here: https://mysqlconnector.net/connection-options/

Essentially this only happens in Mysql 8+ using modern mysql-password plugin and when connecting without using SSL.

In my case I am connecting localhost so I do not need SSL.